### PR TITLE
Add ClipBrowser Swift package

### DIFF
--- a/ClipBrowser/.gitignore
+++ b/ClipBrowser/.gitignore
@@ -1,0 +1,8 @@
+.DS_Store
+/.build
+/Packages
+xcuserdata/
+DerivedData/
+.swiftpm/configuration/registries.json
+.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+.netrc

--- a/ClipBrowser/GraphQL/schema.graphqls
+++ b/ClipBrowser/GraphQL/schema.graphqls
@@ -1,0 +1,9 @@
+type Query {
+  scenes: [Scene!]!
+}
+
+"""A scene from Stash"""
+type Scene {
+  id: ID!
+  title: String!
+}

--- a/ClipBrowser/Package.resolved
+++ b/ClipBrowser/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "1ea3d5044b831c32af202132f69f2dc40b19cc9033be6fb0c9cad0a561327e44",
+  "pins" : [
+    {
+      "identity" : "apollo-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apollographql/apollo-ios.git",
+      "state" : {
+        "revision" : "39fea7617346c0731be25f61afd537e7032fb562",
+        "version" : "1.22.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ClipBrowser/Package.swift
+++ b/ClipBrowser/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 6.1
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "ClipBrowser",
+    platforms: [
+        .macOS(.v13)
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.9.1")
+    ],
+    targets: [
+        .executableTarget(
+            name: "ClipBrowser",
+            dependencies: [
+                .product(name: "Apollo", package: "apollo-ios")
+            ],
+            resources: [
+                .process("GraphQL/schema.graphqls")
+            ]
+        ),
+    ]
+)

--- a/ClipBrowser/Sources/ClipBrowserApp.swift
+++ b/ClipBrowser/Sources/ClipBrowserApp.swift
@@ -1,0 +1,86 @@
+import SwiftUI
+import Apollo
+
+@main
+struct ClipBrowserApp: App {
+    var body: some Scene {
+        WindowGroup {
+            SceneListView()
+        }
+    }
+}
+
+struct SceneListView: View {
+    @State private var scenes: [Scene] = []
+    @State private var loadingError: Error?
+
+    var body: some View {
+        NavigationView {
+            List(scenes) { scene in
+                Text(scene.title)
+            }
+            .navigationTitle("Scenes")
+            .task {
+                await loadScenes()
+            }
+        }
+        .alert("Error", isPresented: .constant(loadingError != nil)) {
+            Button("OK") { loadingError = nil }
+        } message: {
+            Text(loadingError?.localizedDescription ?? "Unknown error")
+        }
+    }
+
+    func loadScenes() async {
+        let client = ApolloClient(url: URL(string: "http://localhost:9999/graphql")!)
+        do {
+            let result = try await client.fetch(query: ScenesQuery())
+            scenes = result.data?.scenes.map { Scene(id: $0.id, title: $0.title) } ?? []
+        } catch {
+            loadingError = error
+        }
+    }
+}
+
+struct Scene: Identifiable {
+    let id: String
+    let title: String
+}
+
+struct ScenesQuery: GraphQLQuery {
+    static let operationDefinition: String = """
+    query ScenesQuery {
+        scenes {
+            id
+            title
+        }
+    }
+    """
+
+    static let operationName: String = "ScenesQuery"
+
+    struct Data: GraphQLSelectionSet {
+        static let selections: [GraphQLSelection] = [
+            GraphQLField("scenes", type: .nonNull(.list(.nonNull(.object(Scene.selections)))))
+        ]
+
+        var resultMap: ResultMap
+
+        var scenes: [Scene] {
+            get { (resultMap["scenes"] as? [ResultMap])?.map { Scene(resultMap: $0) } ?? [] }
+            set { resultMap.updateValue(newValue.map { $0.resultMap }, forKey: "scenes") }
+        }
+
+        struct Scene: GraphQLSelectionSet {
+            static let selections: [GraphQLSelection] = [
+                GraphQLField("id", type: .nonNull(.scalar(String.self))),
+                GraphQLField("title", type: .nonNull(.scalar(String.self)))
+            ]
+
+            var resultMap: ResultMap
+
+            var id: String { resultMap["id"]! as! String }
+            var title: String { resultMap["title"]! as! String }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- create ClipBrowser Swift package for macOS
- add a minimal GraphQL schema
- add SwiftUI Scene browser example using Apollo

## Testing
- `swift build` *(fails: no such module 'os' when compiling Apollo plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6849fd0943548331a4867b402abafea4