### PR TITLE
Add StashViewerApp macOS project skeleton

### DIFF
--- a/StashViewerApp/GraphQL/API.swift
+++ b/StashViewerApp/GraphQL/API.swift
@@ -1,0 +1,1 @@
+// Apollo generated API placeholder

--- a/StashViewerApp/GraphQL/GetClips.graphql
+++ b/StashViewerApp/GraphQL/GetClips.graphql
@@ -1,0 +1,1 @@
+# Sample query

--- a/StashViewerApp/GraphQL/schema.graphqls
+++ b/StashViewerApp/GraphQL/schema.graphqls
@@ -1,0 +1,1 @@
+# GraphQL Schema placeholder

--- a/StashViewerApp/Models/README.txt
+++ b/StashViewerApp/Models/README.txt
@@ -1,0 +1,1 @@
+Placeholder for models

--- a/StashViewerApp/Network/GraphQLManager.swift
+++ b/StashViewerApp/Network/GraphQLManager.swift
@@ -1,0 +1,11 @@
+import Apollo
+
+final class GraphQLManager {
+    static let shared = GraphQLManager()
+    let client: ApolloClient
+
+    private init() {
+        let url = URL(string: "http://localhost:9999/graphql")!
+        client = ApolloClient(url: url)
+    }
+}

--- a/StashViewerApp/Package.resolved
+++ b/StashViewerApp/Package.resolved
@@ -1,0 +1,14 @@
+{
+  "pins" : [
+    {
+      "identity" : "apollo-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apollographql/apollo-ios.git",
+      "state" : {
+        "revision" : "39fea7617346c0731be25f61afd537e7032fb562",
+        "version" : "1.22.0"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/StashViewerApp/Package.swift
+++ b/StashViewerApp/Package.swift
@@ -1,0 +1,41 @@
+// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "StashViewerApp",
+    platforms: [
+        .macOS(.v13)
+    ],
+    products: [
+        .executable(name: "StashViewerApp", targets: ["StashViewerApp"])
+    ],
+    dependencies: [
+        .package(url: "https://github.com/apollographql/apollo-ios.git", from: "1.0.0")
+    ],
+    targets: [
+        .executableTarget(
+            name: "StashViewerApp",
+            dependencies: [
+                .product(name: "Apollo", package: "apollo-ios")
+            ],
+            path: ".",
+            exclude: [
+                "Scripts",
+                "Resources",
+                "GraphQL/schema.graphqls"
+            ],
+            sources: [
+                "Sources/StashViewerApp",
+                "Network",
+                "Views",
+                "Models",
+                "GraphQL"
+            ]
+        ),
+        .testTarget(
+            name: "StashViewerAppTests",
+            dependencies: ["StashViewerApp"],
+            path: "Tests"
+        )
+    ]
+)

--- a/StashViewerApp/Resources/README.txt
+++ b/StashViewerApp/Resources/README.txt
@@ -1,0 +1,1 @@
+Placeholder for resources

--- a/StashViewerApp/Scripts/fetch_and_codegen.sh
+++ b/StashViewerApp/Scripts/fetch_and_codegen.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# Directory of this script
+DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$DIR/.." && pwd)"
+
+SCHEMA_PATH="$PROJECT_ROOT/GraphQL/schema.graphqls"
+API_OUTPUT_DIR="$PROJECT_ROOT/GraphQL"
+
+# Fetch schema from local Stash server
+curl -o "$SCHEMA_PATH" http://localhost:9999/graphql/schema
+
+# Run Apollo codegen
+apollo-ios-cli generate \
+  --schema "$SCHEMA_PATH" \
+  --output "$API_OUTPUT_DIR" \
+  --module-name API \
+  "$PROJECT_ROOT/GraphQL"/*.graphql

--- a/StashViewerApp/Sources/StashViewerApp/StashViewerApp.swift
+++ b/StashViewerApp/Sources/StashViewerApp/StashViewerApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct StashViewerApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ClipBrowserView()
+        }
+    }
+}

--- a/StashViewerApp/Tests/StashViewerAppTests/StashViewerAppTests.swift
+++ b/StashViewerApp/Tests/StashViewerAppTests/StashViewerAppTests.swift
@@ -1,0 +1,8 @@
+import XCTest
+@testable import StashViewerApp
+
+final class StashViewerAppTests: XCTestCase {
+    func testExample() {
+        XCTAssertTrue(true)
+    }
+}

--- a/StashViewerApp/Views/ClipBrowserView.swift
+++ b/StashViewerApp/Views/ClipBrowserView.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+struct ClipBrowserView: View {
+    var body: some View {
+        Text("Hello, Clips!")
+            .padding()
+    }
+}
+
+#Preview {
+    ClipBrowserView()
+}


### PR DESCRIPTION
## Summary
- initialize `StashViewerApp` Swift package targeting macOS 13
- add SwiftUI entry point showing `ClipBrowserView`
- create `GraphQLManager` wrapper for Apollo client
- provide top-level folders for GraphQL, Views, Models, Resources, and Scripts
- include a schema/codegen helper script

## Testing
- `swift build` *(fails: no such module 'os' from apollo-ios plugin)*
- `swift test` *(fails: no such module 'os' from apollo-ios plugin)*

------
https://chatgpt.com/codex/tasks/task_e_684a02325e4c83319d886d538eb35707